### PR TITLE
Changed the openvz kernel repo to an axsh hosted mirror

### DIFF
--- a/guestroot.openvz/etc/yum.repos.d/openvz.repo
+++ b/guestroot.openvz/etc/yum.repos.d/openvz.repo
@@ -1,6 +1,6 @@
 [openvz-kernel-rhel6]
 name=OpenVZ RHEL6-based kernel
-baseurl=http://download.openvz.org/kernel/branches/rhel6-2.6.32/042stab055.16/
+baseurl=http://dlc.wakame.axsh.jp/mirror/openvz/kernel/branches/rhel6-2.6.32/042stab055.16/
 enabled=1
 gpgcheck=1
 gpgkey=http://download.openvz.org/RPM-GPG-Key-OpenVZ


### PR DESCRIPTION
OpenVZ has removed 042stab055.16 from their repository. Until we update, we will have to host it ourselves.
